### PR TITLE
Added pandas dependency

### DIFF
--- a/examples/train-using-nfs/scikit-learn-on-amlarc-with-nfs/scikit-learn-on-amlarc-with-nfs.ipynb
+++ b/examples/train-using-nfs/scikit-learn-on-amlarc-with-nfs/scikit-learn-on-amlarc-with-nfs.ipynb
@@ -141,7 +141,7 @@
     "from azureml.core.conda_dependencies import CondaDependencies\n",
     "\n",
     "myenv = Environment(\"myenv\")\n",
-    "myenv.python.conda_dependencies = CondaDependencies.create(conda_packages=['scikit-learn', 'packaging'])\n",
+    "myenv.python.conda_dependencies = CondaDependencies.create(conda_packages=['scikit-learn', 'packaging', 'pandas'])\n",
     "\n",
     "# Enable Docker\n",
     "docker_config = DockerConfiguration(use_docker=True)"


### PR DESCRIPTION
Pandas dependency was missed in the `conda_dependencies` for the Docker image, caused this error when the Training pod spins up:

`UserError: User program failed with ModuleNotFoundError: No module named pandas`

![image](https://user-images.githubusercontent.com/46581776/131217893-ed666538-a47f-4de5-9911-a5d4c008e930.png)
