### PR TITLE
Adding migration export scripts

### DIFF
--- a/docs/migrate-aks-service-to-amlarc.md
+++ b/docs/migrate-aks-service-to-amlarc.md
@@ -49,7 +49,7 @@ about AmlArc, and understand your using scenarios also the corresponding [networ
 Check `deploy-amlarc.sh`, fill in all the parameters, and find the right scenarios under step2. 
 Then install AmlArc extension by run:
 ```bash
-./deploy-amlarc.sh
+./migrate-aks-service.sh
 ```
 
 The script will register feature provider for your sub, and install extension into your cluster.

--- a/docs/migrate-aks-service-to-amlarc.md
+++ b/docs/migrate-aks-service-to-amlarc.md
@@ -1,0 +1,71 @@
+# Migrate AKS service to AmlArc
+
+We provide two paths for AKS service to [AmlArc](https://docs.microsoft.com/en-us/azure/machine-learning/how-to-attach-arc-kubernetes?tabs=studio#prerequisites) migration.
+Both of them are limit to migrations under the **same workspace**.
+
+| | Direct migration| Export & deploy|
+|--------| ----------- | ----------- | 
+| Support service types | AKS, ACI | AKS, ACI|                     
+| Migration target types| AmlArc| AmlArc, MIR|
+| Migration target| Same cluster | Any cluster|
+| Keep old service| No | Yes|
+| Same service name| Yes| Partially support<sup>1</sup>|
+| Keep scoring url| Yes | Partially support<sup>2</sup>|
+
+> Notes: 
+>1. Export & deploy does not support same name in same cluster.
+>2. Deploy to a new cluster will change the ip address.
+
+After decide your migration path, some scripts can help complete the process:
+1. `migrate-aks-service.sh` Direct migration in same cluster.
+2. `deploy-amlarc.sh` Help install AmlArc extension to your AKS cluster.
+3. `export-service.sh` Export services to template and deploy to AmlArc compute.
+
+## Prerequisites
+Before export and migrate your service, please check the following prerequisites:
+1. A healthy AKS webservice.
+2. An AKS cluster, ready for AmlArc to deploy. Check [prerequisites for AmlArc](https://docs.microsoft.com/en-us/azure/machine-learning/how-to-attach-arc-kubernetes?tabs=studio#prerequisites).
+3. Python package: azureml-core >= 1.37.0.
+4. Cli: azure-cli >= 2.30.0, storage-preview >= 0.7.4, k8s-extension >= 1.0.0.
+5. A shell environment (bash is recommended), make sure the VNet connectivity with your cluster, if any.
+
+## Direct migration
+Make sure you have read the [docs](https://docs.microsoft.com/en-us/azure/machine-learning/how-to-attach-arc-kubernetes?tabs=studio#deploy-azure-machine-learning-extension)
+about AmlArc. Check `migrate-aks-service.sh`, fill in all the parameters, and find the right scenarios under OPTIONS. 
+Then migrate your aks service by run:
+```bash
+./export-service-util
+```
+> Attention: direct migration is a irreversible process. 
+
+## Export & deploy
+
+### Install AmlArc extension on an AKS cluster
+Make sure you have read the [docs](https://docs.microsoft.com/en-us/azure/machine-learning/how-to-attach-arc-kubernetes?tabs=studio#deploy-azure-machine-learning-extension)
+about AmlArc, and understand your using scenarios also the corresponding [network requirements](https://github.com/Azure/AML-Kubernetes/blob/master/docs/network-requirements.md).
+* Scene1: Secure connection through [private link AML Workspace](https://docs.microsoft.com/en-us/azure/machine-learning/how-to-attach-arc-kubernetes?tabs=studio#deploy-azure-machine-learning-extension).
+* Scene2: Cluster is behind an [outbound proxy](https://docs.microsoft.com/en-us/azure/azure-arc/kubernetes/quickstart-connect-cluster?tabs=azure-cli#4a-connect-using-an-outbound-proxy-server).
+
+Check `deploy-amlarc.sh`, fill in all the parameters, and find the right scenarios under step2. 
+Then install AmlArc extension by run:
+```bash
+./deploy-amlarc.sh
+```
+
+The script will register feature provider for your sub, and install extension into your cluster.
+
+### Export and deploy AKS service to AmlArc compute
+The `export-service.sh` will run following steps:
+1. Attach your AmlArc deployed AKS cluster as compute target to Workspace.
+2. Export AKS/ACI services as template and upload to your storage.
+3. Download template and modify parameters.
+4. Deploy to AmlArc compute as online-endpoint and online-deployment service.
+> Attention:
+> - Old services will be kept after a successful export and deployment.
+> - You can set online-endpoint name to the same with old service, but DO NOT deploy to the same cluster, a direct migration is recommended for this scenario.
+
+Check `export-service.sh`, fill in all your parameters, then export and deploy to your cluster by run:
+>./export-service.sh
+
+If you want to export and deploy multiple services, the steps before STEP2 in the script is a one-time procedure.
+After a successful deployment, you can check the online-endpoint and online-deployment through portal or [AzuremlCli](https://docs.microsoft.com/en-us/azure/machine-learning/reference-azure-machine-learning-cli).

--- a/docs/migrate-aks-service-to-amlarc.md
+++ b/docs/migrate-aks-service-to-amlarc.md
@@ -34,7 +34,7 @@ Make sure you have read the [docs](https://docs.microsoft.com/en-us/azure/machin
 about AmlArc. Check `migrate-aks-service.sh`, fill in all the parameters, and find the right scenarios under OPTIONS. 
 Then migrate your aks service by run:
 ```bash
-./export-service-util
+./migrate-aks-service.sh
 ```
 > Attention: direct migration is a irreversible process. 
 
@@ -49,7 +49,7 @@ about AmlArc, and understand your using scenarios also the corresponding [networ
 Check `deploy-amlarc.sh`, fill in all the parameters, and find the right scenarios under step2. 
 Then install AmlArc extension by run:
 ```bash
-./migrate-aks-service.sh
+./deploy-amlarc.sh
 ```
 
 The script will register feature provider for your sub, and install extension into your cluster.

--- a/files/deploy-amlarc.sh
+++ b/files/deploy-amlarc.sh
@@ -14,28 +14,29 @@ ssl_key_pem_file="<YOUR_KEY_PEM_FILE>"
 
 # STEP1 Register feature providers
 echo 'Register features...'
-az feature register --namespace Microsoft.ContainerService -n AKS-ExtensionManager --subscription "$subscription_id"> /dev/null
+az feature register --namespace Microsoft.ContainerService -n AKS-ExtensionManager --subscription "$subscription_id"
 echo 'Waiting for feature register...'
 while [ "$(az feature list --query "[?contains(name, 'Microsoft.ContainerService/AKS-ExtensionManager')].[properties.state]" -o json |jq '.[0][0]')" == 'Registered' ]
 do
   sleep 5
 done
-az provider register -n Microsoft.ContainerService 1> /dev/null
+az provider register -n Microsoft.ContainerService 1
 
 
 # STEP2 Deploy AmlArc extension
+# OPTION A) AKS service has public https endpoint
 az k8s-extension create --cluster-name $cluster_name --cluster-type managedClusters -n $arcml_extension_name \
 --extension-type Microsoft.AzureML.Kubernetes --scope cluster --configuration-settings enableInference=True isAKSMigration=true \
 scoringFe.namespace=default sslCname=$ssl_cname --config-protected sslCertPemFile=$ssl_cert_pem_file sslKeyPemFile=$ssl_key_pem_file \
 --subscription $subscription_id -g $resource_group --auto-upgrade-minor-version False
 
-# OPTIONAL B) AKS service has public http endpoint
+# OPTION B) AKS service has public http endpoint
 #az k8s-extension create --cluster-name $cluster_name --cluster-type managedClusters -n $arcml_extension_name \
 #--extension-type Microsoft.AzureML.Kubernetes --scope cluster --configuration-settings enableInference=True allowInsecureConnections=true \
 #isAKSMigration=true scoringFe.namespace=default \
 #--subscription $subscription_id -g $resource_group --auto-upgrade-minor-version False
 
-# OPTIONAL C) AKS service has private http endpoint
+# OPTION C) AKS service has private http endpoint
 #az k8s-extension create --cluster-name $cluster_name --cluster-type managedClusters -n $arcml_extension_name \
 #--extension-type Microsoft.AzureML.Kubernetes --scope cluster --configuration-settings enableInference=True allowInsecureConnections=true \
 #privateEndpointILB=True isAKSMigration=true scoringFe.namespace=default \
@@ -51,6 +52,3 @@ else
   echo "AzureML extention creation failed"
   exit 1
 fi
-
-
-

--- a/files/deploy-amlarc.sh
+++ b/files/deploy-amlarc.sh
@@ -26,21 +26,19 @@ az provider register -n Microsoft.ContainerService 1
 # STEP2 Deploy AmlArc extension
 # OPTION A) AKS service has public https endpoint
 az k8s-extension create --cluster-name $cluster_name --cluster-type managedClusters -n $arcml_extension_name \
---extension-type Microsoft.AzureML.Kubernetes --scope cluster --configuration-settings enableInference=True isAKSMigration=true \
-scoringFe.namespace=default sslCname=$ssl_cname --config-protected sslCertPemFile=$ssl_cert_pem_file sslKeyPemFile=$ssl_key_pem_file \
+--extension-type Microsoft.AzureML.Kubernetes --scope cluster --configuration-settings enableInference=True \
+sslCname=$ssl_cname --config-protected sslCertPemFile=$ssl_cert_pem_file sslKeyPemFile=$ssl_key_pem_file \
 --subscription $subscription_id -g $resource_group --auto-upgrade-minor-version False
 
 # OPTION B) AKS service has public http endpoint
 #az k8s-extension create --cluster-name $cluster_name --cluster-type managedClusters -n $arcml_extension_name \
 #--extension-type Microsoft.AzureML.Kubernetes --scope cluster --configuration-settings enableInference=True allowInsecureConnections=true \
-#isAKSMigration=true scoringFe.namespace=default \
 #--subscription $subscription_id -g $resource_group --auto-upgrade-minor-version False
 
 # OPTION C) AKS service has private http endpoint
 #az k8s-extension create --cluster-name $cluster_name --cluster-type managedClusters -n $arcml_extension_name \
 #--extension-type Microsoft.AzureML.Kubernetes --scope cluster --configuration-settings enableInference=True allowInsecureConnections=true \
-#privateEndpointILB=True isAKSMigration=true scoringFe.namespace=default \
-#--subscription $subscription_id -g $resource_group --auto-upgrade-minor-version False
+#privateEndpointILB=True --subscription $subscription_id -g $resource_group --auto-upgrade-minor-version False
 
 
 extension_install_state=$(az k8s-extension show --name $arcml_extension_name  --cluster-type managedClusters --cluster-name "$cluster_name"   --resource-group "$resource_group" --subscription "$subscription_id" | jq -r '.provisioningState')

--- a/files/deploy-amlarc.sh
+++ b/files/deploy-amlarc.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+set -e
+
+subscription_id="<YOUR_SUBSCRIPTION_ID>"
+resource_group="<YOUR_RESOURCE_GROUP>"
+cluster_name="<YOUR_AKS_CLUSTER_NAME>"
+
+arcml_extension_name="arcml-extension"
+
+ssl_cname="<YOUR_SSL_CNAME>"
+ssl_cert_pem_file="<YOUR_CERT_PEM_FILE>"
+ssl_key_pem_file="<YOUR_KEY_PEM_FILE>"
+
+# STEP1 Register feature providers
+echo 'Register features...'
+az feature register --namespace Microsoft.ContainerService -n AKS-ExtensionManager --subscription "$subscription_id"> /dev/null
+echo 'Waiting for feature register...'
+while [ "$(az feature list --query "[?contains(name, 'Microsoft.ContainerService/AKS-ExtensionManager')].[properties.state]" -o json |jq '.[0][0]')" == 'Registered' ]
+do
+  sleep 5
+done
+az provider register -n Microsoft.ContainerService 1> /dev/null
+
+
+# STEP2 Deploy AmlArc extension
+az k8s-extension create --cluster-name $cluster_name --cluster-type managedClusters -n $arcml_extension_name \
+--extension-type Microsoft.AzureML.Kubernetes --scope cluster --configuration-settings enableInference=True isAKSMigration=true \
+scoringFe.namespace=default sslCname=$ssl_cname --config-protected sslCertPemFile=$ssl_cert_pem_file sslKeyPemFile=$ssl_key_pem_file \
+--subscription $subscription_id -g $resource_group --auto-upgrade-minor-version False
+
+# OPTIONAL B) AKS service has public http endpoint
+#az k8s-extension create --cluster-name $cluster_name --cluster-type managedClusters -n $arcml_extension_name \
+#--extension-type Microsoft.AzureML.Kubernetes --scope cluster --configuration-settings enableInference=True allowInsecureConnections=true \
+#isAKSMigration=true scoringFe.namespace=default \
+#--subscription $subscription_id -g $resource_group --auto-upgrade-minor-version False
+
+# OPTIONAL C) AKS service has private http endpoint
+#az k8s-extension create --cluster-name $cluster_name --cluster-type managedClusters -n $arcml_extension_name \
+#--extension-type Microsoft.AzureML.Kubernetes --scope cluster --configuration-settings enableInference=True allowInsecureConnections=true \
+#privateEndpointILB=True isAKSMigration=true scoringFe.namespace=default \
+#--subscription $subscription_id -g $resource_group --auto-upgrade-minor-version False
+
+
+extension_install_state=$(az k8s-extension show --name $arcml_extension_name  --cluster-type managedClusters --cluster-name "$cluster_name"   --resource-group "$resource_group" --subscription "$subscription_id" | jq -r '.provisioningState')
+echo "$extension_install_state"
+if [[ $extension_install_state == "Succeeded" ]]
+then
+  echo "AzureML extention created successfully"
+else
+  echo "AzureML extention creation failed"
+  exit 1
+fi
+
+
+

--- a/files/export-service-util.py
+++ b/files/export-service-util.py
@@ -1,0 +1,200 @@
+import json
+import argparse
+import tempfile
+from azureml.core import Workspace
+from azureml.exceptions import WebserviceException
+from azureml.core.compute import KubernetesCompute, ComputeTarget
+from azureml._model_management._util import _get_mms_url
+from azureml._model_management._util import get_paginated_results
+from azureml._model_management._util import get_requests_session
+from azureml._model_management._constants import AKS_WEBSERVICE_TYPE, ACI_WEBSERVICE_TYPE, UNKNOWN_WEBSERVICE_TYPE
+from azureml._model_management._constants import MMS_SYNC_TIMEOUT_SECONDS
+from azureml.core.webservice import Webservice
+from azureml._restclient.clientbase import ClientBase
+
+MIGRATION_WEBSERVICE_TYPES = [AKS_WEBSERVICE_TYPE, ACI_WEBSERVICE_TYPE]
+
+
+def attach(ws: Workspace,
+           compute_name: str,
+           cluster_name: str,
+           namespace: str = None):
+    """
+    Attach AmlArc compute to the workspace.
+    :param cluster_name: AKS cluster name.
+    :param namespace: Compute namespace, if not provided will be set to 'default' namespace
+    :param compute_name: Compute name.
+    :param ws: Target workspace.
+    """
+    resource_id = f"'/subscriptions/{ws.subscription_id}/resourceGroups/{ws.resource_group}/providers/" \
+                  f"Microsoft.ContainerService/managedClusters/{cluster_name}"
+    compute_id = None
+    if compute_name in ws.compute_targets:
+        amlarc_compute = ws.compute_targets[compute_name]
+        if amlarc_compute and type(amlarc_compute) is KubernetesCompute:
+            compute_id = amlarc_compute.id
+    else:
+        amlarc_attach_configuration = KubernetesCompute.attach_configuration(resource_id, namespace=namespace)
+        amlarc_compute = ComputeTarget.attach(ws, compute_name, amlarc_attach_configuration)
+        amlarc_compute.wait_for_completion(show_output=True)
+        compute_id = amlarc_compute.id
+    print(compute_id)
+
+
+def export(ws: Workspace,
+           compute_type: str = None,
+           timeout_seconds: int = None,
+           show_output: bool = True) -> (str, str):
+    """
+    Export all services under target workspace into template and parameters,
+    valid compute_types are "AKS"/"ACI", default to export for both two types.
+    :param show_output: Whether print outputs.
+    :param timeout_seconds: Timeout settings for waiting export.
+    :param ws: Target workspace.
+    :param compute_type: Compute type to export.
+    """
+    base_url = _get_mms_url(ws)
+    mms_endpoint = base_url + '/services'
+    webservices = []
+    headers = {'Content-Type': 'application/json'}
+    headers.update(ws._auth_object.get_authentication_header())
+    params = None
+    if compute_type:
+        if compute_type.upper() not in MIGRATION_WEBSERVICE_TYPES:
+            raise WebserviceException('Invalid compute type "{}". Valid options are "{}"'
+                                      .format(compute_type, ",".join(())))
+        params = {'computeType': compute_type}
+    try:
+        resp = ClientBase._execute_func(get_requests_session().get, mms_endpoint, headers=headers,
+                                        params=params, timeout=MMS_SYNC_TIMEOUT_SECONDS)
+    except:
+        raise WebserviceException(f'Cannot list WebServices ' +
+                                  (f'with type: {compute_type}' if compute_type else ''))
+    content = resp.content
+    if isinstance(resp.content, bytes):
+        content = resp.content.decode("utf-8")
+    services_payload = json.loads(content)
+    for service_dict in get_paginated_results(services_payload, headers):
+        service_type = service_dict['computeType']
+        child_class = None
+
+        for child in Webservice._all_subclasses(Webservice):
+            if service_type == child._webservice_type:
+                child_class = child
+                break
+            elif child._webservice_type == UNKNOWN_WEBSERVICE_TYPE:
+                child_class = child
+
+        if child_class:
+            service_obj = child_class.deserialize(ws, service_dict)
+            webservices.append(service_obj)
+    if len(webservices) == 0:
+        raise WebserviceException(f'No Webservices found in workspace ' +
+                                  (f'with type: {compute_type}' if compute_type else ''))
+    service_entity = webservices[0]
+
+    mms_endpoint = base_url + '/services/export'
+    export_payload = {"computeType": compute_type}
+    resp = ClientBase._execute_func(get_requests_session().post, mms_endpoint, params=params, headers=headers,
+                                    json=export_payload)
+
+    if resp.status_code == 202:
+        service_entity.state = 'Exporting'
+        operation_url = _get_mms_url(service_entity.workspace) + f'/operations/{resp.content.decode("utf-8")}'
+        service_entity._operation_endpoint = operation_url
+        state, _, operation = service_entity._wait_for_operation_to_complete(show_output, timeout_seconds)
+        if state == "Succeeded":
+            export_folder = operation.get("resourceLocation").split("/")[-1]
+            storage_account = service_entity.workspace.get_details().get("storageAccount")
+            if show_output:
+                print(f"Services have been exported to storage account: {storage_account} \n"
+                      f"Folder path: azureml/{export_folder}")
+            return storage_account.split("/")[-1], export_folder
+    else:
+        raise WebserviceException('Received bad response from Model Management Service:\n'
+                                  'Response Code: {}\n'
+                                  'Headers: {}\n'
+                                  'Content: {}'.format(resp.status_code, resp.headers, resp.content))
+
+
+def overwrite_parameters(parms: dict,
+                         target_compute: str,
+                         endpoint_name: str = None,
+                         deployment_name: str = None):
+    """
+    Overwrite parameters
+    :param deployment_name: v2 online-deployment name. Default will be v1 service name.
+    :param endpoint_name: v2 online-endpoint name. Default will be v1 service name.
+    :param target_compute: v2 compute target. For export to AmlArc, the compute should be a cluster with AmlArc extension installed cluster.
+    :param parms: parameters as dict: loaded v2 parameters.
+    """
+    properties = parms["onlineEndpointProperties"]["value"]
+    traffic = parms["onlineEndpointPropertiesTrafficUpdate"]["value"]
+    if target_compute:
+        properties["target"] = target_compute
+        traffic["target"] = target_compute
+    properties.pop("keys")
+    traffic.pop("keys")
+    if endpoint_name:
+        parms["onlineEndpointName"]["value"] = endpoint_name
+
+    # this is optional
+    if deployment_name:
+        parms["onlineDeployments"]["value"][0]["name"] = deployment_name
+        traffic["traffic"][deployment_name] = traffic["traffic"].pop(list(traffic["traffic"].keys())[0])
+
+    temp_file = tempfile.NamedTemporaryFile(mode="w+", suffix=".json", delete=False)
+    json.dump(online_endpoint_deployment, temp_file)
+    temp_file.flush()
+    print(temp_file.name)
+
+
+if __name__ == "__main__":
+
+    def parse_args():
+        parser = argparse.ArgumentParser(description="Export v1 service script")
+
+        parser.add_argument('--attach', action='store_true', help='using script for attach amlarc compute')
+        parser.add_argument('--export', action='store_true', help='using script for export services')
+        parser.add_argument('--overwrite-parameters', action='store_true',
+                            help='using script for overwrite parameters purpose')
+        parser.add_argument('-w', '--workspace', type=str, help='workspace name')
+        parser.add_argument('-g', '--resource-group', type=str, help='resource group name')
+        parser.add_argument('-s', '--subscription', type=str, help='subscription id')
+        parser.add_argument('-c', '--compute-type', default=None, type=str,
+                            help='compute type to export, available types are AKS and ACI, default to export for both '
+                                 'two types')
+        parser.add_argument('--cluster-name', type=str, help='AmlArc installed cluster name')
+        parser.add_argument('--compute-name', default='inferencecompute', type=str, help='compute name')
+        parser.add_argument('--compute-namespace', type=str, help='compute attach namespace')
+        parser.add_argument('-e', '--export-json', action='store_true', dest='export_json',
+                            help='show export result in json')
+        parser.add_argument('-mp', '--parameters-path', type=str, help='parameters file path')
+        parser.add_argument('-mc', '--migrate-compute', type=str, help='v2 compute target name for migrate.')
+        parser.add_argument('-me', '--migrate-endpoint-name', type=str, default=None,
+                            help='v2 online-endpoint name, default is v1 service name')
+        parser.add_argument('-md', '--migrate-deployment-name', type=str, default=None,
+                            help='v2 online-deployment name, default is v1 service name')
+        parser.set_defaults(compute_type=None)
+        return parser.parse_args()
+
+    # parse args
+    args = parse_args()
+
+    if args.attach:
+        workspace = Workspace.get(name=args.workspace, resource_group=args.resource_group, subscription_id=args.subscription)
+        attach(workspace, args.compute_name, args.cluster_name, args.compute_namespace)
+
+    if args.export:
+        worskpace = Workspace.get(name=args.workspace, resource_group=args.resource_group, subscription_id=args.subscription)
+        storage_account, blob_folder = export(worskpace, args.compute_type, show_output=not args.export_json)
+        if args.export_json:
+            print(json.dumps({"storage_account": storage_account, "blob_folder": blob_folder}))
+
+    if args.overwrite_parameters:
+        with open(args.parameters_path) as f:
+            online_endpoint_deployment = json.load(f)
+        overwrite_parameters(online_endpoint_deployment,
+                             args.migrate_compute,
+                             args.migrate_endpoint_name,
+                             args.migrate_deployment_name)

--- a/files/export-service-util.py
+++ b/files/export-service-util.py
@@ -62,7 +62,7 @@ def export(ws: Workspace,
     if compute_type:
         if compute_type.upper() not in MIGRATION_WEBSERVICE_TYPES:
             raise WebserviceException('Invalid compute type "{}". Valid options are "{}"'
-                                      .format(compute_type, ",".join(())))
+                                      .format(compute_type, ",".join(MIGRATION_WEBSERVICE_TYPES)))
         params = {'computeType': compute_type}
     try:
         resp = ClientBase._execute_func(get_requests_session().get, mms_endpoint, headers=headers,

--- a/files/export-service.sh
+++ b/files/export-service.sh
@@ -28,7 +28,6 @@ fi
 
 # STEP1 Export services
 echo 'Export services...'
-#read storage_account blob_folder < <(python3 export-service-util.py --export --export-json -w $workspace_name -g $resource_group -s $subscription_id|tail -1| jq -r '"\(.storage_account) \(.blob_folder)"')
 output=$(python3 export-service-util.py --export --export-json -w $workspace_name -g $resource_group -s $subscription_id| tee /dev/tty)
 read -r storage_account blob_folder < <(echo "$output" |tail -n1| jq -r '"\(.storage_account) \(.blob_folder)"')
 

--- a/files/export-service.sh
+++ b/files/export-service.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+set -e
+
+subscription_id="<YOUR_SUBSCRIPTION_ID>"
+resource_group="<YOUR_RESOURCE_GROUP>"
+workspace_name="<YOUR_WORKSPACE_NAME>"
+v1_compute="<YOUR_COMPUTE_TARGET>" # Compute target of your aks/aci service
+v1_service_name="<YOUR_SERVICE_NAME>" # Service name of your aks/aci service
+local_dir="<PATH_TO_DOWNLOAD_EXPORTED_FILES>"
+
+migrate_type="<MIGRATION_TYPE>" # AmlArc/Managed
+cluster_name="<CLUSTER_NAME>" # required for AmlArc
+compute_name="arcml-compute" # required for AmlArc
+compute_namespace="<COMPUTE_NAMESPACE>"
+online_endpoint_name="<ONLINE_ENDPOINT_NAME>"
+online_deployment_name="<ONLINE_DEPLOYMENT_NAME>"
+
+# OPTIONAL STEP) Attach compute for AmlArc, make sure your cluster have installed AmlArc successfully
+if [[ $migrate_type == "AmlArc" ]]
+then
+  resource_id="/subscriptions/$subscription_id/resourceGroups/$resource_group/providers/Microsoft.ContainerService/managedClusters/$cluster_name"
+  # If you are providing an arc-enabled cluster, using the resource id below
+  # resource_id="/subscriptions/$subscription_id/resourceGroups/$resource_group/providers/Microsoft.ContainerService/managedClusters/$cluster_name"
+  az ml compute attach -n "$compute_name" --namespace "$compute_namespace" -g "$resource_group" -w "$workspace_name" --resource-id "$resource_id" -t Kubernetes --only-show-errors
+  migrate_compute=$(az ml compute show -n "$compute_name" -g "$resource_group" -w "$workspace_name" --only-show-errors -o json| jq -r '.id')
+fi
+
+# STEP1 Export services
+echo 'Export services...'
+#read storage_account blob_folder < <(python3 export-service-util.py --export --export-json -w $workspace_name -g $resource_group -s $subscription_id|tail -1| jq -r '"\(.storage_account) \(.blob_folder)"')
+output=$(python3 export-service-util.py --export --export-json -w $workspace_name -g $resource_group -s $subscription_id| tee /dev/tty)
+read -r storage_account blob_folder < <(echo "$output" |tail -n1| jq -r '"\(.storage_account) \(.blob_folder)"')
+
+# STEP2 Download template & parameters files
+echo 'Download files...'
+az storage blob directory download -c azureml --account-name "$storage_account" -s "$blob_folder" -d $local_dir --recursive --subscription $subscription_id --only-show-errors 1> /dev/null
+
+# STEP3 Overwrite parameters
+echo 'Overwrite parameters...'
+echo
+params_file="$local_dir/$blob_folder/$v1_compute/$migrate_type/$v1_service_name.params.json"
+template_file="$local_dir/$blob_folder/online.endpoint.template.json"
+output=$(python3 export-service-util.py --overwrite-parameters -mp "$params_file" -mc "$migrate_compute" -me "$online_endpoint_name" -md "$online_deployment_name"| tee /dev/tty)
+params=$(echo "$output"|tail -n1)
+
+# STEP4 Deploy to AMLArc/MIR
+echo
+echo "Params have been saved to $params"
+echo "Deploy $migrate_type service $online_endpoint_name..."
+deployment_name="Migration-$online_endpoint_name-$(echo $RANDOM | md5sum | head -c 4)"
+az deployment group create --name "$deployment_name" --resource-group "$resource_group" --template-file "$template_file" --parameters "$params" --subscription $subscription_id
+

--- a/files/export-service.sh
+++ b/files/export-service.sh
@@ -20,8 +20,6 @@ online_deployment_name="<ONLINE_DEPLOYMENT_NAME>"
 if [[ $migrate_type == "AmlArc" ]]
 then
   resource_id="/subscriptions/$subscription_id/resourceGroups/$resource_group/providers/Microsoft.ContainerService/managedClusters/$cluster_name"
-  # If you are providing an arc-enabled cluster, using the resource id below
-  # resource_id="/subscriptions/$subscription_id/resourceGroups/$resource_group/providers/Microsoft.ContainerService/managedClusters/$cluster_name"
   az ml compute attach -n "$compute_name" --namespace "$compute_namespace" -g "$resource_group" -w "$workspace_name" --resource-id "$resource_id" -t Kubernetes --only-show-errors
   migrate_compute=$(az ml compute show -n "$compute_name" -g "$resource_group" -w "$workspace_name" --only-show-errors -o json| jq -r '.id')
 fi

--- a/files/export-service.sh
+++ b/files/export-service.sh
@@ -47,4 +47,3 @@ echo "Params have been saved to $params"
 echo "Deploy $migrate_type service $online_endpoint_name..."
 deployment_name="Migration-$online_endpoint_name-$(echo $RANDOM | md5sum | head -c 4)"
 az deployment group create --name "$deployment_name" --resource-group "$resource_group" --template-file "$template_file" --parameters "$params" --subscription $subscription_id
-


### PR DESCRIPTION
Adding Migration export scripts.

deploy-amlarc.sh: bash script for deploy amlarc on raw aks cluster.
export-service.sh: bash script for migrating aks/aci service to amlarc/mir.
export-service-util.py: python script helper for export and overwrite parameters.