### PR TITLE
Trying to fix "/docs/docs" issue

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -29,4 +29,4 @@ New features are released at a biweekly cadance.
 
 **Oct 14, 2021 Release**
 
-* [PV/PVC volume mount support in AMLArc training job](./docs/pvc.md).
+* [PV/PVC volume mount support in AMLArc training job](./pvc.md).


### PR DESCRIPTION
"./docs/pvc.md" leads to "https://github.com/Azure/AML-Kubernetes/edit/master/docs/release-notes.md"
Removing the extra "./doc" to prevent this.
Other links are also broken, but this is only one simple enough to be corrected by me on a pinch :)